### PR TITLE
Update cloudflare-ufw.sh

### DIFF
--- a/cloudflare-ufw.sh
+++ b/cloudflare-ufw.sh
@@ -16,5 +16,8 @@ ufw reload > /dev/null
 # Restrict to port 443
 #for cfip in `cat /tmp/cf_ips`; do ufw allow proto tcp from $cfip to any port 443 comment 'Cloudflare IP'; done
 
-# Restrict to ports 80 & 443
-#for cfip in `cat /tmp/cf_ips`; do ufw allow proto tcp from $cfip to any port 80,443 comment 'Cloudflare IP'; done
+# Restrict to port 2048 (Railgun)
+#for cfip in `cat /tmp/cf_ips`; do ufw allow proto tcp from $cfip to any port 2048/tcp comment 'Cloudflare IP'; done
+
+# Restrict to ports 80, 443, 2048
+#for cfip in `cat /tmp/cf_ips`; do ufw allow proto tcp from $cfip to any port 80,443,2048/tcp comment 'Cloudflare IP'; done


### PR DESCRIPTION
Cloudflare's Railgun runs on port 2048:

https://developers.cloudflare.com/railgun/user-guide/set-up/preparing-environment

"Railgun runs on port 2408 via TCP by default and this port will need to be open to connections from Cloudflare IPs. If you are unfamiliar with networking, please reach out to your hosting provider to determine the proper way to open the port for your environment."